### PR TITLE
fix(container): renovate regex is flipped

### DIFF
--- a/chart/tailscale-derp/Chart.yaml
+++ b/chart/tailscale-derp/Chart.yaml
@@ -3,5 +3,5 @@ name: tailscale-derp
 description: Run a custom tailscale derp server on Kubernetes.
 type: application
 version: 0.3.0
-# renovate: depName=ghcr.io/coreweave/tailscale-derp datasource=docker
+# renovate: datasource=docker depName=ghcr.io/coreweave/tailscale-derp
 appVersion: "v1.68.0"


### PR DESCRIPTION
Our custom regex manager had a breaking change and is backwards.