### PR TITLE
feat(helm): add sources to Chart.yaml

### DIFF
--- a/chart/tailscale-derp/Chart.yaml
+++ b/chart/tailscale-derp/Chart.yaml
@@ -5,3 +5,5 @@ type: application
 version: 0.3.2
 # renovate: datasource=docker depName=ghcr.io/coreweave/tailscale-derp
 appVersion: "v1.68.1"
+sources:
+  - https://github.com/coreweave/tailscale-derp


### PR DESCRIPTION
This is useful annotation which adds the OCI label `org.opencontainers.image.source`. That should make renovatebot more aware of the artifact.