### PR TITLE
fix(ci): improve automation process

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,15 +1,5 @@
 {
   extends: [
     "github>coreweave/renovate-config"
-  ],
-  packageRules: [
-    {
-      description: "Loose versioning for semver with semi-incrementing build metadata",
-      matchDatasources: ["docker"],
-      matchPackageNames: [
-        "ghcr.io/coreweave/tailscale-derp",
-      ],
-      versioning: "loose",
-    },
   ]
 }

--- a/.github/workflows/charts-publish-oci.yaml
+++ b/.github/workflows/charts-publish-oci.yaml
@@ -8,13 +8,18 @@ on:
   workflow_dispatch: {}
   workflow_call: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   publish-charts:
     name: Publish chart
     permissions:
       contents: write
       packages: write
-    runs-on: ubuntu-22.04
+      pull-requests: write
+      actions: write
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -26,6 +26,8 @@ jobs:
     permissions:
       contents: write
       packages: write
+      pull-requests: write
+      actions: write
     runs-on: ubuntu-22.04
 
     steps:
@@ -42,18 +44,16 @@ jobs:
           labels: |
             org.opencontainers.image.source="https://github.com/tailscale/tailscale"
           tags: |
-            type=ref,event=branch
             type=ref,event=pr
-            type=schedule
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ env.UPSTREAM_TS_VERSION }}
-            type=raw,value=${{ env.UPSTREAM_TS_VERSION }}+{{date 'YYYYMMDD-HHmmss'}}.{{sha}}
+            type=raw,value=${{ env.UPSTREAM_TS_VERSION }}-{{sha}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.6.1
+        uses: docker/setup-buildx-action@v3.7.1
 
       - name: Log into registry ghcr.io
         uses: docker/login-action@v3.3.0
@@ -64,7 +64,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6.7.0
+        uses: docker/build-push-action@v6.9.0
         with:
           push: ${{ github.event_name != 'pull_request' }}
           cache-from: type=gha
@@ -76,3 +76,41 @@ jobs:
           build-args: |
             VERSION=${{ env.UPSTREAM_TS_VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
+
+      - name: Update Helm Chart Image
+        id: update-helm-chart
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          TAG=${{ fromJSON(steps.meta.outputs.json).tags[2] }}
+          VERSION=$(echo "$TAG" | cut -d ':' -f 2)
+          yq eval ".appVersion = \"$VERSION\"" -i chart/tailscale-derp/Chart.yaml
+          yq ".appVersion" chart/tailscale-derp/Chart.yaml
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        id: cpr
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "feat(container): update to ${{ fromJSON(steps.meta.outputs.json).tags[2] }}"
+          body: "Updating helm appVersion to ${{ fromJSON(steps.meta.outputs.json).tags[2] }}"
+          branch: bump-helm-image
+          delete-branch: true
+          author: |
+            dependa-jr[bot] <171952447+dependa-jr[bot]@users.noreply.github.com>
+          committer: |
+            dependa-jr[bot] <171952447+dependa-jr[bot]@users.noreply.github.com>
+          title: |
+            "feat(container): update to ${{ fromJSON(steps.meta.outputs.json).tags[2] }}"
+
+      - name: Enable Pull Request Automerge
+        if: ${{ github.event_name != 'pull_request' }}
+        run: gh pr merge --squash --auto ${{ steps.cpr.outputs.pull-request-number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run release.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,16 +7,24 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   release:
     name: Release
     permissions:
       contents: write
+      packages: write
       pull-requests: write
-    runs-on: ubuntu-22.04
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
+      actions: write
+    runs-on: ubuntu-24.04
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: release
         uses: googleapis/release-please-action@v4
         id: release
@@ -24,12 +32,18 @@ jobs:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
 
-  publish-helm:
-    name: Publish Helm OCI
-    needs: release
-    if: ${{ needs.release.outputs.release_created }}
-    uses: coreweave/tailscale-derp/.github/workflows/charts-publish-oci.yaml@main
-    secrets: inherit
-    permissions:
-      contents: write
-      packages: write
+      - name: Dispatch Helm Action
+        if: ${{ contains(steps.release.outputs.paths_released, 'chart/tailscale-derp') }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run charts-publish-oci.yaml
+
+      - name: Create Release
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR=$(echo '${{ steps.release.outputs.pr }}' | jq -r .number)
+          gh pr merge --squash --auto $PR
+          gh workflow run release.yaml

--- a/chart/tailscale-derp/Chart.yaml
+++ b/chart/tailscale-derp/Chart.yaml
@@ -3,7 +3,6 @@ name: tailscale-derp
 description: Run a custom tailscale derp server on Kubernetes.
 type: application
 version: 0.6.0
-# renovate: datasource=docker depName=ghcr.io/coreweave/tailscale-derp
 appVersion: "v1.74.0"
 sources:
-  - https://github.com/coreweave/tailscale-derp
+  - "https://github.com/coreweave/tailscale-derp"


### PR DESCRIPTION
* Bump GHA marketplace actions
* Auto-cut helm releases
* Bump appVersion automatically when container get's built
* Remove unneeded renovate packageRule
* Revise appVersion structure to offer `latest`, upstreamVersion-sha, and upstreamVersion
* Remove un-needed renovate annotation
* Quote sources to prevent helm-bug from stripping away OCI label `org.opencontainers.image.source`