### PR TITLE
feat(container): add support for verify-clients

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -4,14 +4,20 @@ ARG VERSION=${VERSION:-v1.68.0}
 # https://tailscale.com/kb/1118/custom-derp-servers/
 RUN go install tailscale.com/cmd/derper@${VERSION}
 RUN go install tailscale.com/cmd/derpprobe@${VERSION}
+RUN go install tailscale.com/cmd/tailscaled@${VERSION}
+RUN go install tailscale.com/cmd/tailscale@${VERSION}
+RUN go install tailscale.com/cmd/containerboot@${VERSION}
 
 FROM ubuntu:noble
-WORKDIR /app
+WORKDIR /usr/local/bin
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY --from=builder /go/bin/derper .
 COPY --from=builder /go/bin/derpprobe .
+COPY --from=builder /go/bin/tailscaled .
+COPY --from=builder /go/bin/tailscale .
+COPY --from=builder /go/bin/containerboot .
 COPY Docker/entrypoint.sh /app/entrypoint.sh
 COPY Docker/healthprobe.sh /app/healthprobe.sh
 

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -1,26 +1,54 @@
 #!/bin/bash
 
-# Initialize the command with the executable
-CMD="/app/derper"
+# Initialize the commands with the executables
+DERP_CMD="/usr/local/bin/derper"
+TSD_CMD="/usr/local/bin/tailscaled"
+TS_CMD="/usr/local/bin/tailscale up"
 
 # Generate derpmap
 jq -n --arg hostname "${DERP_HOSTNAME}" '{"Regions":{"900":{"RegionID":900,"Nodes":[{"Name":"900","HostName":$hostname}]}}}' > /app/derpmap.json
 
 # Loop through all environment variables
 for VAR in $(env); do
-  # Check if the variable starts with DERP_
-  if [[ $VAR == DERP_* ]]; then
-    # Extract the name and value
-    VAR_NAME=$(echo "$VAR" | cut -d= -f1)
-    VAR_VALUE=$(echo "$VAR" | cut -d= -f2-)
+  # Check if the variable starts with DERP_, TSD_, or TS_
+  case "$VAR" in
+    DERP_*|TSD_*|TS_*)
+      # Extract the name and value
+      VAR_NAME=$(echo "$VAR" | cut -d= -f1)
+      VAR_VALUE=$(echo "$VAR" | cut -d= -f2-)
 
-    # Convert the variable name to lowercase and replace underscores with hyphens
-    ARG_NAME=$(echo "$VAR_NAME" | sed 's/^DERP_//' | tr '[:upper:]' '[:lower:]' | tr '_' '-')
-    
-    # Append the argument to the command
-    CMD="$CMD --$ARG_NAME=$VAR_VALUE"
-  fi
+      # Convert the variable name to an argument name
+      # Remove the prefix, replace underscores with dashes, and convert to lowercase
+      ARG_NAME=$(echo "$VAR_NAME" | sed -E 's/^(DERP_|TSD_|TS_)//; s/_/-/g; y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/')
+      
+      # Append the argument to command based on argument name
+      case "$VAR_NAME" in
+        DERP_*)
+          DERP_CMD="$DERP_CMD --$ARG_NAME=$VAR_VALUE"
+          echo "Adding $ARG_NAME=$VAR_VALUE to DERP_CMD"
+          ;;
+        TSD_*)
+          TSD_CMD="$TSD_CMD --$ARG_NAME=$VAR_VALUE"
+          echo "Adding $ARG_NAME=$VAR_VALUE to TSD_CMD"
+          ;;
+        TS_*)
+          TS_CMD="$TS_CMD --$ARG_NAME=$VAR_VALUE"
+          # We don't want to log the auth key
+          echo "Adding $ARG_NAME to TS_CMD"
+          ;;
+      esac
+      ;;
+  esac
+
 done
 
-# Execute the command
-exec $CMD
+# Start tailscaled and call tailscale up if we need to verify clients
+if [[ $DERP_VERIFY_CLIENTS == "true" && $CONTAINERBOOT == "false" ]]; then
+  # Start and background tailscaled
+  setsid $TSD_CMD > /dev/stdout 2> /dev/stderr &
+  # Start and background tailscale up
+  setsid $TS_CMD > /dev/stdout 2> /dev/stderr &
+fi
+
+# Execute the derper
+exec $DERP_CMD

--- a/Docker/healthprobe.sh
+++ b/Docker/healthprobe.sh
@@ -9,7 +9,20 @@ if [[ "$response" -lt "200" ]] || [[ "$response" -ge "400" ]]; then
     exit 1
 fi
 
-/app/derpprobe --derp-map file:///app/derpmap.json  --once
+
+if [[ $DERP_VERIFY_CLIENTS == "true" && $CONTAINERBOOT == "false" ]];
+  then
+    DERP_MAP="local"
+    if ! /usr/local/bin/tailscale status --peers=false --json | grep -q 'Online.*true'
+      then
+        echo "Tailscale is not online and DERP_VERIFY_CLIENTS is true"
+        exit 1
+      fi; 
+  else
+    DERP_MAP="file:///app/derpmap.json"
+fi
+
+/usr/local/bin/derpprobe --derp-map $DERP_MAP --once
 
 if [ $? -ne 0 ]; then
   echo "Error: derpprobe failed"

--- a/chart/tailscale-derp/templates/deployment.yaml
+++ b/chart/tailscale-derp/templates/deployment.yaml
@@ -52,6 +52,26 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             {{- tpl (toYaml .Values.volumeMounts) .  | nindent 12 }}
+        {{- range .Values.env }}
+        {{- if and (eq .name "DERP_VERIFY_CLIENTS") (eq .value "true") }}
+        - name: {{ $.Chart.Name }}-tailscaled
+          securityContext:
+            {{- toYaml ($.Values).tailscaled.securityContext | nindent 12 }}
+          env:
+            {{- tpl (toYaml ($.Values).tailscaled.env) . | nindent 12 }}
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
+          command: ["/usr/local/bin/containerboot"]
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          livenessProbe:
+            {{- toYaml $.Values.tailscaled.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml $.Values.tailscaled.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml $.Values.tailscaled.resources | nindent 12 }}
+          volumeMounts:
+            {{- tpl (toYaml $.Values.tailscaled.volumeMounts) .  | nindent 12 }}
+        {{- end }}
+        {{- end }}
       volumes:
         {{- tpl (toYaml .Values.volumes) .  | nindent 8 }}
       {{- with .Values.nodeSelector }}

--- a/chart/tailscale-derp/values.yaml
+++ b/chart/tailscale-derp/values.yaml
@@ -41,6 +41,7 @@ env:
         resource: limits.memory
   - name: DERP_HOSTNAME
     value: '{{ include "tailscale-derp.hostname" . }}'
+  # // Pass extra arguments to derper
   # - name: DERP_CERTMODE
   #   value: "manual"
   # - name: DERP_CERTDIR
@@ -53,9 +54,32 @@ env:
   #   value: "80"
   # - name: DERP_STUN
   #   value: "true"
-  # - name: DERP_DERP
-  #   value: "true"
+  # If using verify-clients, configure the tailscaled container below
+  # - name: DERP_VERIFY_CLIENTS
+  #   value: "false"
 
+# // Configure tailscaled container when using verify-clients
+tailscaled: {}
+  # volumeMounts:
+  #   - name: pipes
+  #     mountPath: /tmp
+  # env:
+  # - name: TS_HEALTHCHECK_ADDR_PORT
+  #   value: 0.0.0.0:9002 # Enable liveness
+  # - name: TS_USERSPACE
+  #   value: "true" # unprivileged
+  # - name: TS_KUBE_SECRET
+  #   value: "" # ephemeral
+  # - name: TS_AUTH_KEY
+  #   value: "" # register with auth key
+  # livenessProbe:
+  #   httpGet:
+  #     path: /healthz
+  #     port: 9002
+  # readinessProbe:
+  #   httpGet:
+  #     path: /healthz
+  #     port: 9002
 
 podSecurityContext: {}
   # fsGroup: 2000
@@ -105,6 +129,7 @@ livenessProbe:
       - /app/healthprobe.sh
   timeoutSeconds: 60
   initialDelaySeconds: 300 # Needs to grab cert
+
 readinessProbe:
   exec:
     command:
@@ -119,13 +144,17 @@ tls: {}
   # domain: '{{ include "tailscale-derp.hostname" . }}'
 
 # Additional volumes on the output Deployment definition.
-volumes: []
+volumes:
+  - name: pipes
+    emptyDir: {}
 # - name: cert
 #   secret:
 #     secretName: '{{ .Release.Name }}-tls'
 
 # Additional volumeMounts on the output Deployment definition.
-volumeMounts: []
+volumeMounts:
+  - name: pipes
+    mountPath: /var/run/tailscale
 # - name: cert
 #   mountPath: '/app/certs/{{ include "tailscale-derp.hostname" . }}.crt'
 #   subPath: tls.crt


### PR DESCRIPTION
Adds support for `derper --verify-clients` by adding `tailscaled` and `tailscale`. 

If `CONTAINERBOOT=false`; I.E running in a single local Docker container, the daemon is backgrounded before calling the main `derper` process, and the Health Check periodically validates if the client is online from the Tailscale control plane, which should catch the daemon exiting. 

The default Helm Chart deployment will instead run `containerboot` to start `tailscaled` in a separate container, sharing the `tailscaled` socket with the `derper` container. In this deployment, we use `containerboot`'s `healthz` endpoint for container probe. 

Closes #70 