### PR TITLE
fix(ci): only commit chart when creating pull request

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -118,6 +118,7 @@ jobs:
           body: "Updating helm appVersion to ${{ fromJSON(steps.meta.outputs.json).tags[2] }}"
           branch: bump-helm-image
           delete-branch: true
+          add-paths: chart/tailscale-derp/Chart.yaml
           author: |
             dependa-jr[bot] <171952447+dependa-jr[bot]@users.noreply.github.com>
           committer: |

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ Session.vim
 **/chart/*.tgz
 
 .history
+
+# Trivy vulnerability DB cache (downloaded into the workspace during CI scans)
+.cache/


### PR DESCRIPTION
Prevents errant files from being swept in the workspace during ci