### PR TITLE
fix(healthprobe): disable derpprobe mesh probe to avoid nil-pointer panic

### DIFF
--- a/Docker/healthprobe.sh
+++ b/Docker/healthprobe.sh
@@ -22,7 +22,11 @@ if [[ $DERP_VERIFY_CLIENTS == "true" && $CONTAINERBOOT == "false" ]];
     DERP_MAP="file:///app/derpmap.json"
 fi
 
-/usr/local/bin/derpprobe --derp-map $DERP_MAP --once
+# This is a single-node DERP region, so there are no peers to mesh with.
+# derpprobe still adds a 900->900 mesh probe by default (--mesh-interval=15s),
+# which panics on a nil pointer when no mesh key is configured. Disable it with
+# --mesh-interval=0 and rely on the TLS probe.
+/usr/local/bin/derpprobe --derp-map $DERP_MAP --mesh-interval=0 --once
 
 if [ $? -ne 0 ]; then
   echo "Error: derpprobe failed"


### PR DESCRIPTION
## Problem

The startup/liveness/readiness probes were failing:

```
Startup probe failed: Error: derpprobe failed
No mesh key found, mesh key is empty
adding DERP TLS probe for 900 () every 15s
adding DERP mesh probe for 900->900 () every 15s
probe derp//900/900/mesh panicked: runtime error: invalid memory address or nil pointer dereference
good: derp//900/tls: 66.832491ms
good: derpmap-probe: 681.632µs
bad: derp//900/900/mesh: panic: runtime error: invalid memory address or nil pointer dereference
```

The `No mesh key found` line is benign. The real failure is the **mesh probe panicking**.

`derpprobe` defaults to `--mesh-interval=15s`, so it always adds a mesh probe in addition to the TLS probe. Our derpmap is a single region (`900`) with a single node, so it creates a self-referential `900->900` mesh probe. With no mesh key configured, that probe hits an unchecked nil dereference (`dm.Regions[rid]` in `prober/derp.go` @ v1.98.3) and panics. The TLS probe passes, but the mesh panic makes `derpprobe --once` exit non-zero → `Error: derpprobe failed` → probe fails.

## Fix

Pass `--mesh-interval=0` to disable the mesh probe (gated on `if d.meshInterval > 0` in the prober). A single-node DERP server has no peers to mesh with, so nothing is lost — the meaningful TLS probe still runs.

## Note

`healthprobe.sh` is baked into the image at build time, so this requires a new image build/release to reach running pods.